### PR TITLE
Add pNet SF class

### DIFF
--- a/interface/AK8GenInterface.h
+++ b/interface/AK8GenInterface.h
@@ -1,0 +1,38 @@
+#ifndef AK8GenInterface_h
+#define AK8GenInterface_h
+
+// ------------------------------------------------------------ //
+//                                                              //
+//   class AK8GenInterface                                      //
+//                                                              //
+//                                                              //
+//   Author: Francesco Brivio (INFN Milano-Bicocca)             //
+//   Date  : June 2024                                          //
+//                                                              //
+// ------------------------------------------------------------ //
+
+#include <vector>
+#include <ROOT/RVec.hxx>
+
+typedef ROOT::VecOps::RVec<float> fRVec;
+typedef ROOT::VecOps::RVec<int> iRVec;
+
+struct gen_match_output {
+    std::vector<bool> Ak8_Zbb_matches;
+    std::vector<bool> Ak8_Hbb_matches;
+};
+
+class AK8GenInterface {
+
+  public:
+    AK8GenInterface();
+    ~AK8GenInterface();
+
+    gen_match_output get_ak8_genmatch_info(
+        iRVec GenPart_statusFlags, iRVec GenPart_pdgId,
+        iRVec GenPart_status, iRVec GenPart_genPartIdxMother,
+        fRVec GenPart_pt, fRVec GenPart_eta, fRVec GenPart_phi, fRVec GenPart_mass,
+        fRVec FatJet_pt, fRVec FatJet_eta, fRVec FatJet_phi, fRVec FatJet_mass);
+};
+
+#endif // AK8GenInterface_h

--- a/interface/HHLeptonInterface.h
+++ b/interface/HHLeptonInterface.h
@@ -120,8 +120,20 @@ class HHLeptonInterface {
       iRVec TrigObj_id, iRVec TrigObj_filterBits, fRVec TrigObj_pt, fRVec TrigObj_eta, fRVec TrigObj_phi,
       std::vector<trig_req> mutau_triggers, std::vector<trig_req> etau_triggers,
       std::vector<trig_req> tautau_triggers, std::vector<trig_req> tautaujet_triggers, 
-      std::vector<trig_req> vbf_triggers
+      std::vector<trig_req> vbf_triggers,
+      bool skip_etau_ele_off, bool skip_etau_tau_off, bool skip_etau_dR, bool skip_etau_trg, bool skip_etau_veto,
+      bool skip_mutau_mu_off, bool skip_mutau_tau_off, bool skip_mutau_dR, bool skip_mutau_trg, bool skip_mutau_veto,
+      bool skip_tautau_tau_off, bool skip_tautau_dR, bool skip_tautau_trg, bool skip_tautau_veto
     );
+    lepton_output get_boosted_tau_indexes(
+      fRVec boostedTau_pt, fRVec boostedTau_eta, fRVec boostedTau_phi, fRVec boostedTau_mass,
+      iRVec boostedTau_idAntiEle2018, iRVec boostedTau_idAntiMu,
+      iRVec boostedTau_idMVAnewDM2017v2, iRVec boostedTau_charge,
+      iRVec TrigObj_id, iRVec TrigObj_filterBits, fRVec TrigObj_pt, fRVec TrigObj_eta, fRVec TrigObj_phi,
+      std::vector<trig_req> boosted_tau_triggers, int Target_TrigObj_id,
+      bool skip_tautau_tau_off, bool skip_tautau_trg
+    );
+
 
     bool lepton_veto(int muon_index, int electron_index,
       fRVec Muon_pt, fRVec Muon_eta, fRVec Muon_dz, fRVec Muon_dxy,
@@ -135,7 +147,14 @@ class HHLeptonInterface {
       float off_pt2, float off_eta2, float off_phi2, int obj_id2,
       std::vector<trig_req> triggers, 
       iRVec TrigObj_id, iRVec TrigObj_filterBits, fRVec TrigObj_pt, fRVec TrigObj_eta, fRVec TrigObj_phi);
-    
+
+    bool pass_trigger_split(
+      float off_pt1, float off_eta1, float off_phi1, int obj_id1,
+      float off_pt2, float off_eta2, float off_phi2, int obj_id2,
+      std::vector<trig_req> triggers, 
+      iRVec TrigObj_id, iRVec TrigObj_filterBits, fRVec TrigObj_pt, fRVec TrigObj_eta, fRVec TrigObj_phi,
+      bool skip_off_1, bool skip_off_2, bool skip_trg);
+
     bool match_trigger_object(float off_eta, float off_phi, int obj_id, float trig_pt_threshold,
       iRVec TrigObj_id, iRVec TrigObj_filterBits, fRVec TrigObj_pt, fRVec TrigObj_eta, fRVec TrigObj_phi,
       std::vector<int> bits);

--- a/interface/PNetSFInterface.h
+++ b/interface/PNetSFInterface.h
@@ -1,0 +1,66 @@
+
+#ifndef PNetSFInterface_h
+#define PNetSFInterface_h
+
+// ---------------------------------------------------------------------------------------------- //
+//                                                                                                //
+//   class PNetSFInterface                                                                        //
+//                                                                                                //
+//   Class to compute ParticleNet ScaleFactors. Modified from original implementation in          //
+//    - https://github.com/LLRCMS/KLUBAnalysis/pull/371                                           //
+//                                                                                                //
+//   Scale factor values from:                                                                    //
+//    - http://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2021_005_v10.pdf (page 76)      //
+//    - Values to be applied ONLY to H->bb events                                                 //
+//                                                                                                //
+//   Author: Francesco Brivio, Simona Palluotto (INFN Milano-Bicocca)                             //
+//   Date  : June 2024                                                                            //
+//                                                                                                //
+// ---------------------------------------------------------------------------------------------- //
+
+// Standard libraries
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// ROOT libraries
+#include <ROOT/RVec.hxx>
+
+class PNetSFInterface {
+
+    public:
+        PNetSFInterface(const std::string period);
+        ~PNetSFInterface();
+        std::vector<float> getSFvec(const ROOT::VecOps::RVec<float> FatJet_pt, const int fatjet_idx,
+                                    const std::vector<bool> genAk8_Zbb_matches, const std::vector<bool> genAk8_Hbb_matches,
+                                    const std::string sampleType);
+
+    private:
+        // Vectors with SF values:
+        //  - 0/1/2 : HP wp -> central, up, down
+        //  - 3/4/5 : MP wp -> central, up, down
+        //  - 6/7/8 : LP wp -> central, up, down
+
+        // SampleType: HH-like
+        std::vector<float> scaleFactorsHH_lowPt_;
+        std::vector<float> scaleFactorsHH_medPt_;
+        std::vector<float> scaleFactorsHH_highPt_;
+
+        // SampleType: TT-like
+        std::vector<float> scaleFactorsTT_lowPt_;
+        std::vector<float> scaleFactorsTT_medPt_;
+        std::vector<float> scaleFactorsTT_highPt_;
+
+        // SampleType: DY-like
+        std::vector<float> scaleFactorsDY_lowPt_;
+        std::vector<float> scaleFactorsDY_medPt_;
+        std::vector<float> scaleFactorsDY_highPt_;
+
+        // Methods to initialiaze the SF maps
+        void FillHHlikeSFs(const std::string period);
+        void FillTTlikeSFs(const std::string period);
+        void FillDYlikeSFs(const std::string period);
+};
+
+#endif // PNetSFInterface_h

--- a/python/AK8Gen.py
+++ b/python/AK8Gen.py
@@ -1,0 +1,61 @@
+import os
+from analysis_tools.utils import import_root
+from Base.Modules.baseModules import JetLepMetSyst
+
+ROOT = import_root()
+
+class AK8GenRDFProducer(JetLepMetSyst):
+    def __init__(self, *args, **kwargs):
+        super(AK8GenRDFProducer, self).__init__(self, *args, **kwargs)
+        self.isMC = kwargs.pop("isMC")
+
+        if self.isMC:
+            if "/libToolsTools.so" not in ROOT.gSystem.GetLibraries():
+                ROOT.gSystem.Load("libToolsTools.so")
+
+            base = "{}/{}/src/Tools/Tools".format(
+                os.getenv("CMT_CMSSW_BASE"), os.getenv("CMT_CMSSW_VERSION"))
+            ROOT.gROOT.ProcessLine(".L {}/interface/AK8GenInterface.h".format(base))
+            ROOT.gInterpreter.Declare("""
+                auto AK8Gen = AK8GenInterface();
+            """)
+
+    def run(self, df):
+        if not self.isMC:
+            return df, []
+
+        variables = ["Ak8_Zbb_matches", "Ak8_Hbb_matches"]
+
+        df = df.Define("ak8_gen_results", "AK8Gen.get_ak8_genmatch_info("
+                            "GenPart_statusFlags, GenPart_pdgId, GenPart_status, "
+                            "GenPart_genPartIdxMother, GenPart_pt, GenPart_eta, "
+                            "GenPart_phi, GenPart_mass, "
+                            "FatJet_pt{0}, FatJet_eta, FatJet_phi, FatJet_mass{0})"
+                            .format(self.jet_syst))
+
+        branches = []
+        for var in variables:
+            df = df.Define(f"gen{var}", f"ak8_gen_results.{var}")
+            branches.append(f"gen{var}")
+
+        return df, branches
+
+
+def AK8GenRDF(**kwargs):
+    """
+    Module to store genMatch information between AK8 and  H/Z->bb
+
+    :param isMC: flag of the dataset being MC or data
+    :type : bool
+
+    YAML sintaxis:
+
+    .. code-block:: yaml
+
+        codename:
+            name: AK8GenRDF
+            path: Tools.Tools.AK8Gen
+            parameters:
+                isMC: self.dataset.process.isMC
+    """
+    return lambda: AK8GenRDFProducer(**kwargs)

--- a/python/HHLepton.py
+++ b/python/HHLepton.py
@@ -440,6 +440,20 @@ class HHLeptonRDFProducer(JetLepMetSyst):
         vvl_vse = kwargs.pop("vvl_vse")
         t_vsmu = kwargs.pop("t_vsmu")
         vl_vsmu = kwargs.pop("vl_vsmu")
+        self.skip_etau_ele_off = kwargs.pop("skip_etau_ele_off", 0)
+        self.skip_etau_tau_off = kwargs.pop("skip_etau_tau_off", 0)
+        self.skip_etau_dR = kwargs.pop("skip_etau_dR", 0)
+        self.skip_etau_trg = kwargs.pop("skip_etau_trg", 0)
+        self.skip_etau_veto = kwargs.pop("skip_etau_veto", 0)
+        self.skip_mutau_mu_off = kwargs.pop("skip_mutau_mu_off", 0)
+        self.skip_mutau_tau_off = kwargs.pop("skip_mutau_tau_off", 0)
+        self.skip_mutau_dR = kwargs.pop("skip_mutau_dR", 0)
+        self.skip_mutau_trg = kwargs.pop("skip_mutau_trg", 0)
+        self.skip_mutau_veto = kwargs.pop("skip_mutau_veto", 0)
+        self.skip_tautau_tau_off = kwargs.pop("skip_tautau_tau_off", 0)
+        self.skip_tautau_dR = kwargs.pop("skip_tautau_dR", 0)
+        self.skip_tautau_trg = kwargs.pop("skip_tautau_trg", 0)
+        self.skip_tautau_veto = kwargs.pop("skip_tautau_veto", 0)
 
         if "/libToolsTools.so" not in ROOT.gSystem.GetLibraries():
             ROOT.gSystem.Load("libToolsTools.so")
@@ -606,49 +620,47 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                         std::vector<trig_req> get_mutau_triggers(
                                 Vbool triggers, bool isMC, int run, int runEra) {
                             std::vector<trig_req> trigger_reqs;
-                            trigger_reqs.push_back(trig_req({triggers[4], 25, 2.3, 20, 2.3, {{2, 8}, {}}}));
-                            trigger_reqs.push_back(trig_req({triggers[5], 28, 2.3, 20, 2.3, {{2, 8}, {}}}));
-                            if (!isMC && run < 317509)
-                                trigger_reqs.push_back(trig_req({triggers[8], 21, 2.3, 32, 2.1, {{64}, {1, 256}}}));
-                            else
-                                trigger_reqs.push_back(trig_req({triggers[9], 21, 2.3, 32, 2.1, {{4}, {1, 16}}}));
+                            trigger_reqs.push_back(trig_req({triggers[4], 26, 2.4, 20, 2.3, 24, 0, {{2, 8}, {}}}));
+                            if (!isMC && run < 317509) {
+                                trigger_reqs.push_back(trig_req({triggers[8], 22, 2.1, 32, 2.1, 0, 27, {{64}, {1, 512}}}));
+                            }
+                            else {
+                                trigger_reqs.push_back(trig_req({triggers[9], 22, 2.1, 32, 2.1, 0, 27, {{64}, {1, 512}}}));
+                            }
                             return trigger_reqs;
                         }
                         std::vector<trig_req> get_etau_triggers(
                                 Vbool triggers, bool isMC, int run, int runEra) {
                             std::vector<trig_req> trigger_reqs;
-                            trigger_reqs.push_back(trig_req({triggers[2], 33, 2.3, 20, 2.3, {{2}, {}}}));
-                            trigger_reqs.push_back(trig_req({triggers[3], 36, 2.3, 20, 2.3, {{2}, {}}}));
-                            if (!isMC && run < 317509)
-                                trigger_reqs.push_back(trig_req({triggers[4], 25, 2.3, 35, 2.1, {{64}, {1, 128}}}));
-                            else
-                                trigger_reqs.push_back(trig_req({triggers[5], 25, 2.3, 35, 2.1, {{8}, {1, 16}}}));
+                            trigger_reqs.push_back(trig_req({triggers[2], 33, 2.5, 20, 2.3, 32, 0, {{2}, {}}}));
+                            if (!isMC && run < 317509) {
+                                trigger_reqs.push_back(trig_req({triggers[4], 25, 2.1, 35, 2.1, 0, 0, {{64}, {1, 256}}}));
+                            }
+                            else {
+                                trigger_reqs.push_back(trig_req({triggers[5], 25, 2.1, 35, 2.1, 0, 0, {{8}, {1, 256}}}));
+                            }
                             return trigger_reqs;
                         }
                         std::vector<trig_req> get_tautau_triggers(
                                 Vbool triggers, bool isMC, bool isRun3, int run, int runEra) {
                             std::vector<trig_req> trigger_reqs;
-                            trigger_reqs.push_back(trig_req({triggers[2], 40, 2.1, 40, 2.1, {{64, 4, 8}, {64, 4, 8}}}));
-                            trigger_reqs.push_back(trig_req({triggers[3], 40, 2.1, 40, 2.1, {{64, 4, 8}, {64, 4, 8}}}));
-                            if (!isMC && run < 317509)
-                                trigger_reqs.push_back(trig_req({triggers[4], 40, 2.1, 40, 2.1, {{64, 4}, {64, 4}}}));
-                            else
-                                trigger_reqs.push_back(trig_req({triggers[5], 40, 2.1, 40, 2.1, {{2, 16}, {2, 16}}}));
+                            if (!isMC && run < 317509) {
+                                trigger_reqs.push_back(trig_req({triggers[2], 40, 2.1, 40, 2.1, 0, 0, {{4, 16, 64}, {4, 16, 64}}}));
+                                trigger_reqs.push_back(trig_req({triggers[3], 40, 2.1, 40, 2.1, 40, 40, {{2, 16, 64}, {2, 16, 64}}}));
+                                trigger_reqs.push_back(trig_req({triggers[4], 40, 2.1, 40, 2.1, 0, 0, {{4, 64}, {4, 64}}}));
+                            }
+                            else {
+                                trigger_reqs.push_back(trig_req({triggers[5], 40, 2.1, 40, 2.1, 0, 0, {{64}, {64}}}));
+                            }
                             return trigger_reqs;
                         }
                         std::vector<trig_req> get_tautaujet_triggers(Vbool triggers, bool isRun3) { // DUMMY FUNCTION
                             std::vector<trig_req> trigger_reqs;
-                            if (isRun3)
-                                trigger_reqs.push_back(trig_req({triggers[0], 35, 2.1, 35, 2.1, {{8, 32, 128, 16384}, {8, 32, 128, 16384}}}));
                             return trigger_reqs;
                         }
                         std::vector<trig_req> get_vbf_triggers(
                                 Vbool triggers, bool isMC, int run, int runEra) {
                             std::vector<trig_req> trigger_reqs;
-                            if (!isMC && run < 317509)
-                                trigger_reqs.push_back(trig_req({triggers[1], 25, 2.1, 25, 2.1, {{64, 4, 8}, {64, 4, 8}}}));
-                            else
-                                trigger_reqs.push_back(trig_req({triggers[2], 25, 2.1, 25, 2.1, {{512, 1, 16}, {512, 1, 16}}}));
                             return trigger_reqs;
                         }
                     """)
@@ -761,16 +773,28 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                 break
         assert runEra != None
 
-        df = df.Define("mutau_triggers", "get_mutau_triggers({%s}, %s, run, %s)" % (
+        skip = ""
+        is_cutflow = (self.skip_etau_ele_off or self.skip_etau_tau_off or self.skip_etau_dR or self.skip_etau_trg or self.skip_etau_veto or \
+                self.skip_mutau_mu_off or self.skip_mutau_tau_off or self.skip_mutau_dR or self.skip_mutau_trg or self.skip_mutau_veto or \
+                self.skip_tautau_tau_off or self.skip_tautau_dR or self.skip_tautau_trg or self.skip_tautau_veto)
+        if is_cutflow:
+            skip = "_skip" + self.skip_etau_ele_off * "_ETau_eleOff" + self.skip_etau_tau_off * "_ETau_tauOff" + \
+                self.skip_etau_dR * "_ETau_dR" + self.skip_etau_trg * "_ETau_Trg" + self.skip_etau_veto * "_ETau_LepVeto" + \
+                self.skip_mutau_mu_off * "_MuTau_muOff" + self.skip_mutau_tau_off * "_MuTau_tauOff" + \
+                self.skip_mutau_dR * "_MuTau_dR" + self.skip_mutau_trg * "_MuTau_Trg" + self.skip_mutau_veto * "_MuTau_LepVeto" + \
+                self.skip_tautau_tau_off * "_TauTau_tauOff" + self.skip_tautau_dR * "_TauTau_dR" + \
+                self.skip_tautau_trg * "_TauTau_Trg" + self.skip_tautau_veto * "_TauTau_LepVeto"
+
+        df = df.Define(f"mutau_triggers{skip}", "get_mutau_triggers({%s}, %s, run, %s)" % (
             ", ".join(self.mutau_triggers), ("true" if self.isMC else "false"), runEra))
-        df = df.Define("etau_triggers", "get_etau_triggers({%s}, %s, run, %s)" % (
+        df = df.Define(f"etau_triggers{skip}", "get_etau_triggers({%s}, %s, run, %s)" % (
             ", ".join(self.etau_triggers), ("true" if self.isMC else "false"), runEra))
-        df = df.Define("tautau_triggers", "get_tautau_triggers({%s}, %s, %s, run, %s)" % (
+        df = df.Define(f"tautau_triggers{skip}", "get_tautau_triggers({%s}, %s, %s, run, %s)" % (
             ", ".join(self.tautau_triggers), ("true" if self.isMC else "false"),
             ("true" if self.isRun3 else "false"), runEra))
-        df = df.Define("tautaujet_triggers", "get_tautaujet_triggers({%s}, %s)" % (
+        df = df.Define(f"tautaujet_triggers{skip}", "get_tautaujet_triggers({%s}, %s)" % (
             ", ".join(self.tautaujet_triggers), ("true" if self.isRun3 else "false")))
-        df = df.Define("vbf_triggers", "get_vbf_triggers({%s}, %s, run, %s)" % (
+        df = df.Define(f"vbf_triggers{skip}", "get_vbf_triggers({%s}, %s, run, %s)" % (
             ", ".join(self.vbf_triggers), ("true" if self.isMC else "false"), runEra))
 
         Electron_mvaIso_WP80 = "Electron_mvaIso_WP80"
@@ -783,7 +807,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
         if Electron_mvaNoIso_WP90 not in all_branches:
             Electron_mvaNoIso_WP90 = "Electron_mvaFall17V2noIso_WP90"
 
-        df = df.Define("hh_lepton_results", "HHLepton.get_dau_indexes("
+        df = df.Define(f"hh_lepton_results{skip}", "HHLepton.get_dau_indexes("
             "Muon_pt{0}, Muon_eta, Muon_phi, Muon_mass{0}, "
             "Muon_pfRelIso04_all, Muon_dxy, Muon_dz, Muon_mediumId, Muon_tightId, Muon_charge, "
             "Electron_pt{1}, Electron_eta, Electron_phi, Electron_mass{1}, "
@@ -794,21 +818,28 @@ class HHLeptonRDFProducer(JetLepMetSyst):
             "Tau_idDeepTau{6}VSjet, Tau_rawDeepTau{6}VSjet, "
             "Tau_dz, Tau_decayMode, Tau_charge, "
             "TrigObj_id, TrigObj_filterBits, TrigObj_pt, TrigObj_eta, TrigObj_phi, "
-            "mutau_triggers, etau_triggers, tautau_triggers, tautaujet_triggers, vbf_triggers"
+            "mutau_triggers{7}, etau_triggers{7}, tautau_triggers{7}, tautaujet_triggers{7}, vbf_triggers{7}, "
+            "{8}, {9}, {10}, {11}, {12}, "
+            "{13}, {14}, {15}, {16}, {17}, "
+            "{18}, {19}, {20}, {21}"
         ")".format(self.muon_syst, self.electron_syst, self.tau_syst,
             Electron_mvaIso_WP80, Electron_mvaNoIso_WP90, Electron_mvaIso_WP90,
-            self.deeptau_version))
+            self.deeptau_version, skip, 
+            self.skip_etau_ele_off, self.skip_etau_tau_off, self.skip_etau_dR, self.skip_etau_trg, self.skip_etau_veto,
+            self.skip_mutau_mu_off, self.skip_mutau_tau_off, self.skip_mutau_dR, self.skip_mutau_trg, self.skip_mutau_veto,
+            self.skip_tautau_tau_off, self.skip_tautau_dR, self.skip_tautau_trg, self.skip_tautau_veto))
 
         branches = []
         for var in variables:
             branchName = var
             if "DeepTau" in branchName:
                 branchName = var[:var.index("VS")] + self.deeptau_version + var[var.index("VS"):]
-            df = df.Define(branchName, "hh_lepton_results.%s" % var)
-            branches.append(branchName)
+            print("hh_lepton_results%s.%s" % (skip, var))
+            df = df.Define(branchName + skip, "hh_lepton_results%s.%s" % (skip, var))
+            branches.append(branchName + skip)
 
         if self.pairType_filter:
-            df = df.Filter("pairType >= 0", "HHLeptonRDF")
+            df = df.Filter(f"pairType{skip} >= 0", f"HHLeptonRDF{skip}")
 
         return df, branches
         # return df, []
@@ -868,9 +899,9 @@ def HHLeptonRDF(**kwargs):
                 t_vsmu: self.config.deeptau.vsmu.Tight
                 vl_vsmu: self.config.deeptau.vsmu.VLoose
                 pairType_filter: True
-
+                skip_etau_ele_off: False
     """
-    pairType_filter = kwargs.pop("pairType_filter")
+    pairType_filter = kwargs.pop("pairType_filter", False)
     return lambda: HHLeptonRDFProducer(pairType_filter=pairType_filter, **kwargs)
 
 

--- a/python/HHLeptonSingleTau.py
+++ b/python/HHLeptonSingleTau.py
@@ -1,0 +1,344 @@
+import os
+
+from analysis_tools.utils import import_root
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
+from Tools.Tools.tau_utils import LeptonTauPair, TriggerChecker, lepton_veto
+from Base.Modules.baseModules import JetLepMetSyst, JetLepMetModule
+
+ROOT = import_root()
+
+class HHLeptonRDFProducer(JetLepMetSyst):
+    def __init__(self, isMC, year, runEra, pairType_filter, *args, **kwargs):
+        super(HHLeptonRDFProducer, self).__init__(isMC=isMC, *args, **kwargs)
+        self.isMC = isMC
+        self.year = year
+        self.runEra = runEra
+        self.isRun3 = kwargs.pop("isRun3", False)
+        self.pairType_filter = pairType_filter
+        self.deeptau_version = kwargs.pop("deeptau_version", "2017v2p1")
+        self.isV10 = kwargs.pop("isV10", False)
+        vvvl_vsjet = kwargs.pop("vvvl_vsjet")
+        vl_vse = kwargs.pop("vl_vse")
+        vvl_vse = kwargs.pop("vvl_vse")
+        t_vsmu = kwargs.pop("t_vsmu")
+        vl_vsmu = kwargs.pop("vl_vsmu")
+        self.skip_etau_ele_off = kwargs.pop("skip_etau_ele_off", 0)
+        self.skip_etau_tau_off = kwargs.pop("skip_etau_tau_off", 0)
+        self.skip_etau_dR = kwargs.pop("skip_etau_dR", 0)
+        self.skip_etau_trg = kwargs.pop("skip_etau_trg", 0)
+        self.skip_etau_veto = kwargs.pop("skip_etau_veto", 0)
+        self.skip_mutau_mu_off = kwargs.pop("skip_mutau_mu_off", 0)
+        self.skip_mutau_tau_off = kwargs.pop("skip_mutau_tau_off", 0)
+        self.skip_mutau_dR = kwargs.pop("skip_mutau_dR", 0)
+        self.skip_mutau_trg = kwargs.pop("skip_mutau_trg", 0)
+        self.skip_mutau_veto = kwargs.pop("skip_mutau_veto", 0)
+        self.skip_tautau_tau_off = kwargs.pop("skip_tautau_tau_off", 0)
+        self.skip_tautau_dR = kwargs.pop("skip_tautau_dR", 0)
+        self.skip_tautau_trg = kwargs.pop("skip_tautau_trg", 0)
+        self.skip_tautau_veto = kwargs.pop("skip_tautau_veto", 0)
+        self.skip_btautau_tau_off = kwargs.pop("skip_btautau_tau_off", 0)
+        self.skip_btautau_trg = kwargs.pop("skip_btautau_trg", 0)
+
+        if "/libToolsTools.so" not in ROOT.gSystem.GetLibraries():
+            ROOT.gSystem.Load("libToolsTools.so")
+
+        # DOCUMENTATION
+        # The list of triggers here is checked against the list of branches in NanoAOD, non-existent ones are replaced by false.
+        # A "Vbool triggers" array is built with the HLT_* trigger paths and passed to get_*tau_triggers functions
+        # Then a trig_req object is built. pass = HLT_* branch (or false in case it does not exist). 
+        # struct trig_req {bool pass; float pt1; float eta1; float pt2; float eta2; std::vector<std::vector<int>> bits; };
+        # the values here are used to make cuts on *offline* objects, nb1 is electron/muon/hadTau, nb2 is hadTau
+
+        self.mutau_triggers = ["HLT_IsoMu22", "HLT_IsoMu22_eta2p1",
+            "HLT_IsoTkMu24", "HLT_IsoTkMu22_eta2p1", "HLT_IsoMu24", "HLT_IsoMu27",
+            "HLT_IsoMu19_eta2p1_LooseIsoPFTau20", "HLT_IsoMu19_eta2p1_LooseIsoPFTau20_SingleL1",
+            "HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1",
+            "HLT_IsoMu20_eta2p1_LooseChargedIsoPFTauHPS27_eta2p1_CrossL1"]
+        self.etau_triggers = ["HLT_Ele25_eta2p1_WPTight_Gsf", "HLT_Ele32_WPTight_Gsf_L1DoubleEG",
+            "HLT_Ele32_WPTight_Gsf", "HLT_Ele35_WPTight_Gsf",
+            "HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1",
+            "HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTauHPS30_eta2p1_CrossL1"]
+        self.tautau_triggers = ["HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg",
+            "HLT_DoubleMediumCombinedIsoPFTau35_Trk1_eta2p1_Reg",
+            "HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg",
+            "HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg",
+            "HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg",
+            "HLT_DoubleMediumChargedIsoPFTauHPS35_Trk1_eta2p1_Reg",
+            "HLT_DoubleMediumDeepTauPFTauHPS35_L2NN_eta2p1"]
+        self.boostedtau_triggers = ["HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1",
+            "HLT_AK8PFJet400_TrimMass30"]
+        self.tautaujet_triggers = ["HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60"]
+        self.vbf_triggers = ["HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg",
+            "HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1",
+            "HLT_VBF_DoubleLooseChargedIsoPFTauHPS20_Trk1_eta2p1"]
+
+        if not os.getenv("_HHLepton"):
+            os.environ["_HHLepton"] = "_HHLepton"
+
+            base = "{}/{}/src/Tools/Tools".format(
+                os.getenv("CMT_CMSSW_BASE"), os.getenv("CMT_CMSSW_VERSION"))
+            ROOT.gROOT.ProcessLine(".L {}/interface/HHLeptonInterface.h".format(base))
+            ROOT.gInterpreter.Declare("""
+                auto HHLepton = HHLeptonInterface(%s, %s, %s, %s, %s);
+            """ % (vvvl_vsjet, vl_vse, vvl_vse, t_vsmu, vl_vsmu))
+
+            if self.year == 2018:
+                ROOT.gInterpreter.Declare("""
+                    using Vbool = const ROOT::RVec<Bool_t>&;
+                    std::vector<trig_req> get_mutau_triggers(
+                            Vbool triggers, bool isMC, int run, int runEra) {
+                        std::vector<trig_req> trigger_reqs;
+                        trigger_reqs.push_back(trig_req({triggers[4], 26, 2.4, 20, 2.3, 24, 0, {{2, 8}, {}}})); // HLT_IsoMu24 (not prescaled for 2018)
+                        // trigger_reqs.push_back(trig_req({triggers[5], 29, 2.4, 20, 2.3, 27, 0, {{2, 8}, {}}})); // HLT_IsoMu27 -> not to be used for 2018
+                        // https://twiki.cern.ch/twiki/bin/view/CMS/TauTrigger
+                        // The TWiki suggests using HLT_IsoMu20_eta2p1_LooseChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1 rather than HLT_IsoMu20_eta2p1_LooseChargedIsoPFTauHPS27_eta2p1_CrossL1 but our SFs are presumably for the latter (trigger used for gamma gamma ->tautau)
+                        // Muon filter bits : 2(->4): *OverlapFilterIsoMu*PFTau*, 6(->64): hlt*OverlapFilterIsoMu*PFTau* (the 2 seem identical ?)
+                        // Tau filter bits : 0(->1): LooseChargedIso, 5(->32): *Hps*, 9(->512): hlt*OverlapFilterIsoMu*PFTau* (mutau)
+                        // Requiring HPS is not in  Tau POG wiki and probably is not needed as all paths matching hlt*OverlapFilterIsoMu*PFTau* are HPS when that is available
+                        // Requiring LooseChargedIso is also not in Tau POG twiki
+                        if (!isMC && run < 317509) {
+                            trigger_reqs.push_back(trig_req({triggers[8], 22, 2.1, 32, 2.1, 0, 27, {{}, {}}})); // HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1
+                        }
+                        else {
+                            // used to be {1, 32} for tau leg which is wrong I think ? that would require every tau LooseIso HPS trigger
+                            trigger_reqs.push_back(trig_req({triggers[9], 22, 2.1, 32, 2.1, 0, 27, {{}, {}}})); // HLT_IsoMu20_eta2p1_LooseChargedIsoPFTauHPS27_eta2p1_CrossL1
+                        }
+                        return trigger_reqs;
+                    }
+                    std::vector<trig_req> get_etau_triggers(
+                            Vbool triggers, bool isMC, int run, int runEra) {
+                        std::vector<trig_req> trigger_reqs;
+                        trigger_reqs.push_back(trig_req({triggers[2], 33, 2.5, 20, 2.3, 32, 0, {{2}, {}}})); // HLT_Ele32_WPTight_Gsf
+                        // trigger_reqs.push_back(trig_req({triggers[3], 36, 2.1, 20, 2.3, {{2}, {}}})); // HLT_Ele35_WPTight_Gsf
+                        // gg->tautau analysis does OR with HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTauHPS30_eta2p1_TightID_CrossL1 but extremly few events pass this and not our trigger (<0.01% in ttbar)
+                        if (!isMC && run < 317509) {
+                            trigger_reqs.push_back(trig_req({triggers[4], 25, 2.1, 35, 2.1, 0, 0, {{}, {}}})); // HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1
+                        }
+                        else {
+                            trigger_reqs.push_back(trig_req({triggers[5], 25, 2.1, 35, 2.1, 0, 0, {{}, {}}})); // HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTauHPS30_eta2p1_CrossL1
+                        }
+                        return trigger_reqs;
+                    }
+                    std::vector<trig_req> get_tautau_triggers(
+                            Vbool triggers, bool isMC, bool isRun3, int run, int runEra) {
+                        std::vector<trig_req> trigger_reqs;
+                        // Tau POG doc for ditau : (same as 2017)
+                        // TrigObj_id == 15 && (TrigObj_filterBits&64)!=0 && (
+                        //        ( (TrigObj_filterBits&4)!=0 && (TrigObj_filterBits&16)!=0 ) ||
+                        //        ( TrigObj_pt > 40 && ( (TrigObj_filterBits&2)!=0 && (TrigObj_filterBits&16)!=0 ) 
+                        //    || (TrigObj_filterBits&4)!=0 ) ) 
+                        // Summary : (4&16&64) || (2&16&64&Trig_pt>40) || (4&64)
+                        // Filter bits : 1(->2):MediumChargedIso, 2(->4):TightChargedIso, 4(->16):TightID OOSC photons (*TightOOSCPhotons*), 6(->64):charged iso di-tau (hlt*DoublePFTau*TrackPt1*ChargedIsolation*Dz02*)
+                        if (!isMC && run < 317509) {
+                            trigger_reqs.push_back(trig_req({triggers[2], 40, 2.1, 40, 2.1, 0, 0, {{}, {}}})); // HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg
+                            // the offline req is indeed 40 GeV according to tau pog twiki, + need to put online 40 GeV req.
+                            trigger_reqs.push_back(trig_req({triggers[3], 40, 2.1, 40, 2.1, 40, 40, {{}, {}}})); // HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg
+                            trigger_reqs.push_back(trig_req({triggers[4], 40, 2.1, 40, 2.1, 0, 0, {{}, {}}})); // HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg
+                        }
+                        else {
+                            trigger_reqs.push_back(trig_req({triggers[5], 40, 2.1, 40, 2.1, 0, 0, {{}, {}}})); // HLT_DoubleMediumChargedIsoPFTauHPS35_Trk1_eta2p1_Reg
+                        }
+                        return trigger_reqs;
+                    }
+                    std::vector<trig_req> get_boosted_tau_triggers(
+                            Vbool triggers, bool isMC, bool isRun3, int run, int runEra) {
+                        std::vector<trig_req> trigger_reqs;
+                        trigger_reqs.push_back(trig_req({triggers[0], 185, 2.1, 20, 2.1, 180, 0, {{}, {}}})); // HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1
+                        return trigger_reqs;
+                    }
+                    std::vector<trig_req> get_tautaujet_triggers(Vbool triggers, bool isRun3) {
+                        std::vector<trig_req> trigger_reqs;
+                        return trigger_reqs;
+                    }
+                    std::vector<trig_req> get_vbf_triggers(
+                            Vbool triggers, bool isMC, int run, int runEra) {
+                        std::vector<trig_req> trigger_reqs;
+                        // if (!isMC && run < 317509)
+                        //     trigger_reqs.push_back(trig_req({triggers[1], 25, 2.1, 25, 2.1, {{1}, {1}}})); // HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1
+                        // else
+                        //     trigger_reqs.push_back(trig_req({triggers[2], 25, 2.1, 25, 2.1, {{1, 32}, {1, 32}}})); // HLT_VBF_DoubleLooseChargedIsoPFTauHPS20_Trk1_eta2p1
+                        return trigger_reqs;
+                    }
+                """)
+
+    def run(self, df):
+        variables = ["pairType", "dau1_index", "dau2_index",
+            "isTauTauJetTrigger", "isVBFtrigger", "isOS",
+            "dau1_eta", "dau1_phi", "dau1_iso", "dau1_decayMode",
+            "dau1_idDeepTauVSe", "dau1_idDeepTauVSmu",
+            "dau1_idDeepTauVSjet",
+            "dau2_eta", "dau2_phi", "dau2_decayMode",
+            "dau2_idDeepTauVSe", "dau2_idDeepTauVSmu",
+            "dau2_idDeepTauVSjet"
+        ]                  
+
+        all_branches = df.GetColumnNames()
+        for ib, branch in enumerate(self.mutau_triggers):
+            if branch not in all_branches:
+                self.mutau_triggers[ib] = "false"
+        for ib, branch in enumerate(self.etau_triggers):
+            if branch not in all_branches:
+                self.etau_triggers[ib] = "false"
+        for ib, branch in enumerate(self.tautau_triggers):
+            if branch not in all_branches:
+                self.tautau_triggers[ib] = "false"
+        for ib, branch in enumerate(self.tautaujet_triggers):
+            if branch not in all_branches:
+                self.tautaujet_triggers[ib] = "false"
+        for ib, branch in enumerate(self.vbf_triggers):
+            if branch not in all_branches:
+                self.vbf_triggers[ib] = "false"
+
+        runEras = ["dum", "A", "B", "C", "D", "E", "F", "G", "H"]
+        runEra = None
+        for _irun, _runEra in enumerate(runEras):
+            if self.runEra == _runEra:
+                runEra = _irun
+                break
+        assert runEra != None
+
+        skip = ""
+        is_cutflow = (self.skip_etau_ele_off or self.skip_etau_tau_off or self.skip_etau_dR or self.skip_etau_trg or self.skip_etau_veto or \
+                self.skip_mutau_mu_off or self.skip_mutau_tau_off or self.skip_mutau_dR or self.skip_mutau_trg or self.skip_mutau_veto or \
+                self.skip_tautau_tau_off or self.skip_tautau_dR or self.skip_tautau_trg or self.skip_tautau_veto or \
+                self.skip_btautau_tau_off or self.skip_btautau_trg)
+        if is_cutflow:
+            skip = "_skip" + self.skip_etau_ele_off * "_ETau_eleOff" + self.skip_etau_tau_off * "_ETau_tauOff" + \
+                self.skip_etau_dR * "_ETau_dR" + self.skip_etau_trg * "_ETau_Trg" + self.skip_etau_veto * "_ETau_LepVeto" + \
+                self.skip_mutau_mu_off * "_MuTau_muOff" + self.skip_mutau_tau_off * "_MuTau_tauOff" + \
+                self.skip_mutau_dR * "_MuTau_dR" + self.skip_mutau_trg * "_MuTau_Trg" + self.skip_mutau_veto * "_MuTau_LepVeto" + \
+                self.skip_tautau_tau_off * "_TauTau_tauOff" + self.skip_tautau_dR * "_TauTau_dR" + \
+                self.skip_tautau_trg * "_TauTau_Trg" + self.skip_tautau_veto * "_TauTau_LepVeto" + \
+                self.skip_btautau_tau_off * "_BTauTau_tauOff" + self.skip_btautau_trg * "_BTauTau_Trg"
+
+        df = df.Define(f"mutau_triggers{skip}", "get_mutau_triggers({%s}, %s, run, %s)" % (
+            ", ".join(self.mutau_triggers), ("true" if self.isMC else "false"), runEra))
+        df = df.Define(f"etau_triggers{skip}", "get_etau_triggers({%s}, %s, run, %s)" % (
+            ", ".join(self.etau_triggers), ("true" if self.isMC else "false"), runEra))
+        df = df.Define(f"tautau_triggers{skip}", "get_tautau_triggers({%s}, %s, %s, run, %s)" % (
+            ", ".join(self.tautau_triggers), ("true" if self.isMC else "false"),
+            ("true" if self.isRun3 else "false"), runEra))
+        df = df.Define(f"boosted_tau_triggers{skip}", "get_boosted_tau_triggers({%s}, %s, %s, run, %s)" % (
+            ", ".join(self.boostedtau_triggers), ("true" if self.isMC else "false"),
+            ("true" if self.isRun3 else "false"), runEra))
+        df = df.Define(f"tautaujet_triggers{skip}", "get_tautaujet_triggers({%s}, %s)" % (
+            ", ".join(self.tautaujet_triggers), ("true" if self.isRun3 else "false")))
+        df = df.Define(f"vbf_triggers{skip}", "get_vbf_triggers({%s}, %s, run, %s)" % (
+            ", ".join(self.vbf_triggers), ("true" if self.isMC else "false"), runEra))
+
+        Electron_mvaIso_WP80 = "Electron_mvaIso_WP80"
+        if Electron_mvaIso_WP80 not in all_branches:
+            Electron_mvaIso_WP80 = "Electron_mvaFall17V2Iso_WP80"
+        Electron_mvaIso_WP90 = "Electron_mvaIso_WP90"
+        if Electron_mvaIso_WP90 not in all_branches:
+            Electron_mvaIso_WP90 = "Electron_mvaFall17V2Iso_WP90"
+        Electron_mvaNoIso_WP90 = "Electron_mvaNoIso_WP90"
+        if Electron_mvaNoIso_WP90 not in all_branches:
+            Electron_mvaNoIso_WP90 = "Electron_mvaFall17V2noIso_WP90"
+
+        df = df.Define(f"hh_lepton_results{skip}", "HHLepton.get_dau_indexes("
+            "Muon_pt{0}, Muon_eta, Muon_phi, Muon_mass{0}, "
+            "Muon_pfRelIso04_all, Muon_dxy, Muon_dz, Muon_mediumId, Muon_tightId, Muon_charge, "
+            "Electron_pt{1}, Electron_eta, Electron_phi, Electron_mass{1}, "
+            "{3}, {4}, {5}, Electron_pfRelIso03_all, "
+            "Electron_dxy, Electron_dz, Electron_charge, "
+            "Tau_pt{2}, Tau_eta, Tau_phi, Tau_mass{2}, "
+            "Tau_idDeepTau{6}VSmu, Tau_idDeepTau{6}VSe, "
+            "Tau_idDeepTau{6}VSjet, Tau_rawDeepTau{6}VSjet, "
+            "Tau_dz, Tau_decayMode, Tau_charge, "
+            "TrigObj_id, TrigObj_filterBits, TrigObj_pt, TrigObj_eta, TrigObj_phi, "
+            "mutau_triggers{7}, etau_triggers{7}, tautau_triggers{7}, tautaujet_triggers{7}, vbf_triggers{7}, "
+            "{8}, {9}, {10}, {11}, {12}, "
+            "{13}, {14}, {15}, {16}, {17}, "
+            "{18}, {19}, {20}, {21}"
+        ")".format(self.muon_syst, self.electron_syst, self.tau_syst,
+            Electron_mvaIso_WP80, Electron_mvaNoIso_WP90, Electron_mvaIso_WP90,
+            self.deeptau_version, skip, 
+            self.skip_etau_ele_off, self.skip_etau_tau_off, self.skip_etau_dR, self.skip_etau_trg, self.skip_etau_veto,
+            self.skip_mutau_mu_off, self.skip_mutau_tau_off, self.skip_mutau_dR, self.skip_mutau_trg, self.skip_mutau_veto,
+            self.skip_tautau_tau_off, self.skip_tautau_dR, self.skip_tautau_trg, self.skip_tautau_veto))
+
+        df = df.Define(f"hh_boosted_tau_results{skip}", "HHLepton.get_boosted_tau_indexes("
+            # "boostedTau_pt{0}, boostedTau_eta, boostedTau_phi, boostedTau_mass{0}, " # [FIXME] no systs for the moment
+            "boostedTau_pt, boostedTau_eta, boostedTau_phi, boostedTau_mass, "
+            "boostedTau_idAntiEle2018, boostedTau_idAntiMu, "
+            "boostedTau_idMVAnewDM2017v2, boostedTau_charge, "
+            "TrigObj_id, TrigObj_filterBits, TrigObj_pt, TrigObj_eta, TrigObj_phi, "
+            "boosted_tau_triggers{0}, 15, "
+            "{1}, {2}"
+        ")".format(
+            # self.tau_syst # [FIXME] no systs for the moment
+            skip, self.skip_btautau_tau_off, self.skip_btautau_trg))
+
+        branches = []
+        for var in variables:
+            branchName = var
+            if "DeepTau" in branchName:
+                branchName = var[:var.index("VS")] + self.deeptau_version + var[var.index("VS"):]
+            df = df.Define(branchName + skip, "hh_lepton_results%s.pairType >= 0 ? hh_lepton_results%s.%s : hh_boosted_tau_results%s.%s" % (skip, skip, var, skip, var))
+            branches.append(branchName + skip)
+
+        if self.pairType_filter:
+            df = df.Filter(f"pairType{skip} >= 0", f"HHLeptonRDF{skip}")
+
+        return df, branches
+
+def HHLeptonRDF(**kwargs):
+    """
+    Returns the index of the two selected taus + several of their variables not affected by
+    systematics.
+
+    Lepton systematics (used for pt and mass variables) can be modified using the parameters from 
+    :ref:`BaseModules_JetLepMetSyst`.
+
+    :param runEra: run period in caps (data only)
+    :type runEra: str
+
+    :param isV10: whether the input sample is from nanoaodV10 (default: ``False``)
+    :type isV10: bool
+
+    :param deeptau_version: version of the DeepTau discriminator (default: ``2017v2p1``)
+    :type deeptau_version: str
+
+    :param vvvl_vsjet: VVVLoose DeepTauVSjet WP value
+    :type vvvl_vsjet: int
+
+    :param vl_vse: VLoose DeepTauVSe WP value
+    :type vl_vse: int
+
+    :param vvl_vse: VVLoose DeepTaVSe WP value
+    :type vvl_vse: int
+
+    :param t_vsmu: Tight DeepTauVSmu WP value
+    :type t_vsmu: int
+
+    :param vl_vsmu: VLoose DeepTauVSmu WP value
+    :type vl_vsmu: int
+
+    :param filter: whether to filter out output events if they don't have 2 lepton candidates
+    :type filter: bool
+
+    YAML sintaxis:
+
+    .. code-block:: yaml
+
+        codename:
+            name: HHLeptonRDF
+            path: Tools.Tools.HHLeptonDev
+            parameters:
+                isMC: self.dataset.process.isMC
+                isV10: self.dataset.has_tag("nanoV10")
+                year: self.config.year
+                runEra: self.dataset.runEra
+                runEra: self.dataset.runEra
+                vvvl_vsjet: self.config.deeptau.vsjet.VVVLoose
+                vl_vse: self.config.deeptau.vse.VLoose
+                vvl_vse: self.config.deeptau.vse.VVLoose
+                t_vsmu: self.config.deeptau.vsmu.Tight
+                vl_vsmu: self.config.deeptau.vsmu.VLoose
+                pairType_filter: True
+
+    """
+    pairType_filter = kwargs.pop("pairType_filter", False)
+    return lambda: HHLeptonRDFProducer(pairType_filter=pairType_filter, **kwargs)

--- a/python/HH_SF.py
+++ b/python/HH_SF.py
@@ -62,3 +62,77 @@ def HHbtag_SFRDF(**kwargs):
     """
     year = kwargs.pop("year")
     return lambda: HHbtag_SFRDFProducer(year, **kwargs)
+
+class HH_pNetSFRDFProduced(JetLepMetSyst):
+    def __init__(self, *args, **kwargs):
+        super(HH_pNetSFRDFProduced, self).__init__(*args, **kwargs)
+        self.isMC = kwargs.pop("isMC")
+        self.year = kwargs.pop("year")
+
+        # Check whether HH-like, TT-like, DY-like or other for pNet SF:
+        #  - HH-like : ggHH, VBFHH, ZH, WH, ttH, ggH, qqH, ttWH, ttZH
+        #  - TT-like : TT fullyLep, semiLep, fullyHad
+        #  - DY_like : all DY samples
+        #  - other   : all other samples
+        dsetName = kwargs.pop("dataset")
+        if "HH" in dsetName or "Hto2B" in dsetName or "WH" in dsetName or "ZH" in dsetName:
+            sampleType = "HHlike"
+        elif "TTto" in dsetName:
+            sampleType = "TTlike"
+        elif "DY" in dsetName:
+            sampleType = "DYlike"
+        else:
+            sampleType = "other"
+        self.sampleType = sampleType
+
+        if self.isMC:
+            base = "{}/{}/src/Tools/Tools".format(os.getenv("CMT_CMSSW_BASE"), os.getenv("CMT_CMSSW_VERSION"))
+            ROOT.gROOT.ProcessLine(".L {}/interface/PNetSFInterface.h".format(base))
+
+            ROOT.gInterpreter.Declare("""
+                auto PNetAK8SF = PNetSFInterface("%s");
+            """ % (self.year))
+
+    def run(self, df):
+        # In case of data: no SFs
+        if not self.isMC:
+            return df, []
+
+        # In case of MC: compute SFs based on jet pT, sample type and gen-matches variables
+        df = df.Define("fatjet_pNet_SF_vec", "PNetAK8SF.getSFvec(FatJet_pt{1}, fatjet_JetIdx, "
+                                             " genAk8_Zbb_matches, genAk8_Hbb_matches, "
+                                             " \"{0}\")".format(self.sampleType, self.jet_syst))
+        df = df.Define("fatjet_pNet_HP_SF",      "fatjet_pNet_SF_vec[0]")
+        df = df.Define("fatjet_pNet_HP_SF_up",   "fatjet_pNet_SF_vec[1]")
+        df = df.Define("fatjet_pNet_HP_SF_down", "fatjet_pNet_SF_vec[2]")
+        df = df.Define("fatjet_pNet_MP_SF",      "fatjet_pNet_SF_vec[3]")
+        df = df.Define("fatjet_pNet_MP_SF_up",   "fatjet_pNet_SF_vec[4]")
+        df = df.Define("fatjet_pNet_MP_SF_down", "fatjet_pNet_SF_vec[5]")
+        df = df.Define("fatjet_pNet_LP_SF",      "fatjet_pNet_SF_vec[6]")
+        df = df.Define("fatjet_pNet_LP_SF_up",   "fatjet_pNet_SF_vec[7]")
+        df = df.Define("fatjet_pNet_LP_SF_down", "fatjet_pNet_SF_vec[8]")
+
+        return df, ["fatjet_pNet_HP_SF", "fatjet_pNet_HP_SF_up", "fatjet_pNet_HP_SF_down",
+                    "fatjet_pNet_MP_SF", "fatjet_pNet_MP_SF_up", "fatjet_pNet_MP_SF_down",
+                    "fatjet_pNet_LP_SF", "fatjet_pNet_LP_SF_up", "fatjet_pNet_LP_SF_down"]
+
+
+def HH_pNetSFRDF(**kwargs):
+    """
+    Module to obtain pNet SFs for AK8 jets depending on sample type,
+    FataJet pT and gen-matching to a H/Z->bb resonance
+
+    YAML sintaxis:
+
+    .. code-block:: yaml
+
+        codename:
+            name: HH_pNetSFRDF
+            path: Tools.Tools.HH_SF
+            parameters:
+                isMC: self.dataset.process.isMC
+                dataset: self.dataset.name
+                year: self.config.year
+
+    """
+    return lambda: HH_pNetSFRDFProduced(**kwargs)

--- a/python/ZZ_ZH_Analysis.py
+++ b/python/ZZ_ZH_Analysis.py
@@ -45,10 +45,16 @@ class BBTauTauFilterRDFProducer():
             ROOT.gInterpreter.Declare("""
                 using Vfloat = const ROOT::RVec<float>&;
                 using Vint   = const ROOT::RVec<int>&;
-                bool find_Zbb_Ztautau (Vint GenPart_pdgId, Vint GenPart_genPartIdxMother) {
-                    bool FoundSignal = false;
+                int GenPairType_Zbb_Ztautau (Vint GenPart_pdgId, Vint GenPart_genPartIdxMother) {
+
+                    int GenPairType = -1;
                     int n_b_fromZ = 0;
                     int n_tau_fromZ = 0;
+                    int tau1_id = -1;
+                    int tau2_id = -1;
+                    int dau1_gen_id = -1;
+                    int dau2_gen_id = -1;
+                    
                     for (int i_gen = 0; i_gen < GenPart_pdgId.size(); i_gen ++) {
                         if (GenPart_genPartIdxMother.at(i_gen) == -1) continue; // it is the incoming parton
                         if ((fabs(GenPart_pdgId.at(i_gen)) == 5) && (GenPart_pdgId.at(GenPart_genPartIdxMother.at(i_gen)) == 23)) {
@@ -56,17 +62,40 @@ class BBTauTauFilterRDFProducer():
                         }
                         if ((fabs(GenPart_pdgId.at(i_gen)) == 15) && (GenPart_pdgId.at(GenPart_genPartIdxMother.at(i_gen)) == 23)) {
                             n_tau_fromZ += 1;
+                            if (tau1_id == -1) tau1_id = i_gen;
+                            else if (tau2_id == -1) tau2_id = i_gen;
                         }
                     }
                     if ((n_b_fromZ > 1) && (n_tau_fromZ > 1)) {
-                        FoundSignal = true;
+                        for (int j_gen = 0; j_gen < GenPart_pdgId.size(); j_gen++) {
+                            if ((GenPart_genPartIdxMother.at(j_gen) == tau1_id) && ((fabs(GenPart_pdgId.at(j_gen)) == 11) || (fabs(GenPart_pdgId.at(j_gen)) == 13))) {
+                                dau1_gen_id = fabs(GenPart_pdgId.at(j_gen));
+                            }
+                            else if ((GenPart_genPartIdxMother.at(j_gen) == tau2_id) && ((fabs(GenPart_pdgId.at(j_gen)) == 11) || (fabs(GenPart_pdgId.at(j_gen)) == 13))) {
+                                dau2_gen_id = fabs(GenPart_pdgId.at(j_gen));
+                            }
+                        }
+                        if (((dau1_gen_id == 11) && (dau2_gen_id == 13)) || ((dau1_gen_id == 13) && (dau2_gen_id == 11))) GenPairType = 3; // decay modes not covered
+                        else if ((dau1_gen_id == 11) || (dau2_gen_id == 11)) GenPairType = 0;
+                        else if ((dau1_gen_id == 13) || (dau2_gen_id == 13)) GenPairType = 1;
+                        else GenPairType = 2;
+                        return GenPairType;
                     }
-                    return FoundSignal;
+                    else {
+                        return -1;
+                    }
                 }
-                bool find_Zbb_Htautau (Vint GenPart_pdgId, Vint GenPart_genPartIdxMother) {
-                    bool FoundSignal = false;
+                
+                int GenPairType_Zbb_Htautau (Vint GenPart_pdgId, Vint GenPart_genPartIdxMother) {
+
+                    int GenPairType = -1;
                     int n_b_fromZ = 0;
                     int n_tau_fromH = 0;
+                    int tau1_id = -1;
+                    int tau2_id = -1;
+                    int dau1_gen_id = -1;
+                    int dau2_gen_id = -1;
+
                     for (int i_gen = 0; i_gen < GenPart_pdgId.size(); i_gen ++) {
                         if (GenPart_genPartIdxMother.at(i_gen) == -1) continue; // it is the incoming parton
                         if ((fabs(GenPart_pdgId.at(i_gen)) == 5) && (GenPart_pdgId.at(GenPart_genPartIdxMother.at(i_gen)) == 23)) {
@@ -74,17 +103,40 @@ class BBTauTauFilterRDFProducer():
                         }
                         if ((fabs(GenPart_pdgId.at(i_gen)) == 15) && (GenPart_pdgId.at(GenPart_genPartIdxMother.at(i_gen)) == 25)) {
                             n_tau_fromH += 1;
+                            if (tau1_id == -1) tau1_id = i_gen;
+                            else if (tau2_id == -1) tau2_id = i_gen;
                         }
                     }
                     if ((n_b_fromZ > 1) && (n_tau_fromH > 1)) {
-                        FoundSignal = true;
+                        for (int j_gen = 0; j_gen < GenPart_pdgId.size(); j_gen++) {
+                            if ((GenPart_genPartIdxMother.at(j_gen) == tau1_id) && ((fabs(GenPart_pdgId.at(j_gen)) == 11) || (fabs(GenPart_pdgId.at(j_gen)) == 13))) {
+                                dau1_gen_id = fabs(GenPart_pdgId.at(j_gen));
+                            }
+                            else if ((GenPart_genPartIdxMother.at(j_gen) == tau2_id) && ((fabs(GenPart_pdgId.at(j_gen)) == 11) || (fabs(GenPart_pdgId.at(j_gen)) == 13))) {
+                                dau2_gen_id = fabs(GenPart_pdgId.at(j_gen));
+                            }
+                        }
+                        if (((dau1_gen_id == 11) && (dau2_gen_id == 13)) || ((dau1_gen_id == 13) && (dau2_gen_id == 11))) GenPairType = 3; // decay modes not covered
+                        else if ((dau1_gen_id == 11) || (dau2_gen_id == 11)) GenPairType = 0;
+                        else if ((dau1_gen_id == 13) || (dau2_gen_id == 13)) GenPairType = 1;
+                        else GenPairType = 2;
+                        return GenPairType;
                     }
-                    return FoundSignal;
+                    else {
+                        return -1;
+                    }
                 }
-                bool find_Ztautau_Hbb (Vint GenPart_pdgId, Vint GenPart_genPartIdxMother) {
-                    bool FoundSignal = false;
+
+                int GenPairType_Ztautau_Hbb (Vint GenPart_pdgId, Vint GenPart_genPartIdxMother) {
+
+                    int GenPairType = -1;
                     int n_b_fromH = 0;
                     int n_tau_fromZ = 0;
+                    int tau1_id = -1;
+                    int tau2_id = -1;
+                    int dau1_gen_id = -1;
+                    int dau2_gen_id = -1;
+
                     for (int i_gen = 0; i_gen < GenPart_pdgId.size(); i_gen ++) {
                         if (GenPart_genPartIdxMother.at(i_gen) == -1) continue; // it is the incoming parton
                         if ((fabs(GenPart_pdgId.at(i_gen)) == 5) && (GenPart_pdgId.at(GenPart_genPartIdxMother.at(i_gen)) == 25)) {
@@ -92,12 +144,28 @@ class BBTauTauFilterRDFProducer():
                         }
                         if ((fabs(GenPart_pdgId.at(i_gen)) == 15) && (GenPart_pdgId.at(GenPart_genPartIdxMother.at(i_gen)) == 23)) {
                             n_tau_fromZ += 1;
+                            if (tau1_id == -1) tau1_id = i_gen;
+                            else if (tau2_id == -1) tau2_id = i_gen;
                         }
                     }
                     if ((n_b_fromH > 1) && (n_tau_fromZ > 1)) {
-                        FoundSignal = true;
+                        for (int j_gen = 0; j_gen < GenPart_pdgId.size(); j_gen++) {
+                            if ((GenPart_genPartIdxMother.at(j_gen) == tau1_id) && ((fabs(GenPart_pdgId.at(j_gen)) == 11) || (fabs(GenPart_pdgId.at(j_gen)) == 13))) {
+                                dau1_gen_id = fabs(GenPart_pdgId.at(j_gen));
+                            }
+                            else if ((GenPart_genPartIdxMother.at(j_gen) == tau2_id) && ((fabs(GenPart_pdgId.at(j_gen)) == 11) || (fabs(GenPart_pdgId.at(j_gen)) == 13))) {
+                                dau2_gen_id = fabs(GenPart_pdgId.at(j_gen));
+                            }
+                        }
+                        if (((dau1_gen_id == 11) && (dau2_gen_id == 13)) || ((dau1_gen_id == 13) && (dau2_gen_id == 11))) GenPairType = 3; // decay modes not covered
+                        else if ((dau1_gen_id == 11) || (dau2_gen_id == 11)) GenPairType = 0;
+                        else if ((dau1_gen_id == 13) || (dau2_gen_id == 13)) GenPairType = 1;
+                        else GenPairType = 2;
+                        return GenPairType;
                     }
-                    return FoundSignal;
+                    else {
+                        return -1;
+                    }
                 }
             """)
 
@@ -107,19 +175,19 @@ class BBTauTauFilterRDFProducer():
             # define a new branch to check if it is or not a ZZ/ZH->bbtautau event
             if self.ProcType == "Zbb_Ztautau":
                 print(" ### Running bbtautau filter for Zbb_Ztautau")
-                df = df.Define("isBBTT", """find_Zbb_Ztautau(
+                df = df.Define("GenPairType", """GenPairType_Zbb_Ztautau(
                     GenPart_pdgId,
                     GenPart_genPartIdxMother
                 )""")
             elif self.ProcType == "Zbb_Htautau":
                 print(" ### Running bbtautau filter for Zbb_Htautau")
-                df = df.Define("isBBTT", """find_Zbb_Htautau(
+                df = df.Define("GenPairType", """GenPairType_Zbb_Htautau(
                     GenPart_pdgId,
                     GenPart_genPartIdxMother
                 )""")
             elif self.ProcType == "Ztautau_Hbb":
                 print(" ### Running bbtautau filter for Ztautau_Hbb")
-                df = df.Define("isBBTT", """find_Ztautau_Hbb(
+                df = df.Define("GenPairType", """GenPairType_Ztautau_Hbb(
                     GenPart_pdgId,
                     GenPart_genPartIdxMother
                 )""")
@@ -129,17 +197,18 @@ class BBTauTauFilterRDFProducer():
             # filter the events with ZZ/ZH->bbtautau
             if self.isSigBBTT:
                 # print(" ### DEBUG: isBBTT == 1")
-                df = df.Filter("isBBTT == 1", "BBTauTauFilterRDF")
+                df = df.Filter("GenPairType != -1", "BBTauTauFilterRDF")
             # filter the events without ZZ/ZH->bbtautau
             elif self.isBkgBBTT:
                 # print(" ### DEBUG: isBBTT == 0")
-                df = df.Filter("isBBTT == 0", "BBTauTauFilterRDF")
+                df = df.Filter("GenPairType == -1", "BBTauTauFilterRDF")
                 
-        return df, []
+        return df, ["GenPairType"]
 
 class BBTauTauFilterDummyRDFProducer():
     def run(self, df):
-        return df, []
+        df = df.Define("GenPairType", -1)
+        return df, ["GenPairType"]
 
 def BBTauTauFilterRDF(*args, **kwargs):
 

--- a/src/AK8GenInterface.cc
+++ b/src/AK8GenInterface.cc
@@ -1,0 +1,96 @@
+#include "Tools/Tools/interface/AK8GenInterface.h"
+#include <iostream>
+#include <algorithm>
+#include <TLorentzVector.h>
+
+// Constructor
+AK8GenInterface::AK8GenInterface() {}
+
+// Destructor
+AK8GenInterface::~AK8GenInterface() {}
+
+// Get ak8 match info
+gen_match_output AK8GenInterface::get_ak8_genmatch_info(
+    iRVec GenPart_statusFlags, iRVec GenPart_pdgId,
+    iRVec GenPart_status, iRVec GenPart_genPartIdxMother,
+    fRVec GenPart_pt, fRVec GenPart_eta, fRVec GenPart_phi, fRVec GenPart_mass,
+    fRVec FatJet_pt, fRVec FatJet_eta, fRVec FatJet_phi, fRVec FatJet_mass)
+{
+    // Declare output
+    gen_match_output genMatchOut;
+
+    // Set all ouput to false
+    for (size_t i = 0; i < FatJet_pt.size(); i++)
+    {
+        genMatchOut.Ak8_Zbb_matches.push_back(false);
+        genMatchOut.Ak8_Hbb_matches.push_back(false);
+    }
+
+    // Declare vectors of gen H/Z->bb idxs
+    std::vector<int> genHbb_idxs, genZbb_idxs;
+
+    // Loop on gen particles to fill the genH and genZ idx vectors
+    for (size_t idx = 0; idx < GenPart_pdgId.size(); idx++)
+    {
+        // Particle gen info
+        int pdg    = GenPart_pdgId[idx];
+        int mthIdx = GenPart_genPartIdxMother[idx];
+        int mthPdg = (mthIdx > -1) ? GenPart_pdgId[mthIdx] : 0;
+
+        bool isFirst       = (GenPart_statusFlags[idx] & (1<<12)) ? true : false;
+        bool isHardProcess = (GenPart_statusFlags[idx] & (1<<7))  ? true : false;
+
+        // If it's a b-quark
+        if (abs(pdg) == 5 && isHardProcess && isFirst)
+        {
+            // Check whether it comes from H...
+            if (abs(mthPdg) == 25)
+            {
+                // If motherH idx already saved (due to other b quark), continue
+                if (std::find(genHbb_idxs.begin(), genHbb_idxs.end(), mthIdx) != genHbb_idxs.end())
+                    continue;
+                // else, save it
+                else
+                    genHbb_idxs.push_back(mthIdx);
+            }
+            // ...or Z
+            else if (abs(mthPdg) == 23)
+            {
+                // If motherZ idx already saved (due to other b quark), continue
+                if (std::find(genZbb_idxs.begin(), genZbb_idxs.end(), mthIdx) != genZbb_idxs.end())
+                    continue;
+                // else, save it
+                else
+                    genZbb_idxs.push_back(mthIdx);
+            }
+        }
+    }
+
+    // Now loop on FatJets and do the geometric matching (dR < 0.8) with the gen H/Z->bb
+    for (size_t i = 0; i < FatJet_pt.size(); i++)
+    {
+        // Reco ak8 jet
+        TLorentzVector fatjet_tlv;
+        fatjet_tlv.SetPtEtaPhiM(FatJet_pt[i], FatJet_eta[i], FatJet_phi[i], FatJet_mass[i]);
+
+        // Matching with H->bb
+        for (auto idx : genHbb_idxs)
+        {
+            TLorentzVector gen_Hbb;
+            gen_Hbb.SetPtEtaPhiM(GenPart_pt[idx], GenPart_eta[idx], GenPart_phi[idx], GenPart_mass[idx]);
+            if (fatjet_tlv.DeltaR(gen_Hbb) < 0.8)
+                genMatchOut.Ak8_Hbb_matches[i] = true;
+        }
+
+        // Matching with Z->bb
+        for (auto idx : genZbb_idxs)
+        {
+            TLorentzVector gen_Zbb;
+            gen_Zbb.SetPtEtaPhiM(GenPart_pt[idx], GenPart_eta[idx], GenPart_phi[idx], GenPart_mass[idx]);
+            if (fatjet_tlv.DeltaR(gen_Zbb) < 0.8)
+                genMatchOut.Ak8_Zbb_matches[i] = true;
+        }
+    }
+
+    return genMatchOut;
+}

--- a/src/PNetSFInterface.cc
+++ b/src/PNetSFInterface.cc
@@ -1,0 +1,354 @@
+#include "Tools/Tools/interface/PNetSFInterface.h"
+#include <iostream> // FIXME: remove
+
+// Constructor
+PNetSFInterface::PNetSFInterface(const std::string period) :
+    // First initialize all SF vectors to 1...
+    scaleFactorsHH_lowPt_ (9, 1.),
+    scaleFactorsHH_medPt_ (9, 1.),
+    scaleFactorsHH_highPt_(9, 1.),
+    scaleFactorsTT_lowPt_ (9, 1.),
+    scaleFactorsTT_medPt_ (9, 1.),
+    scaleFactorsTT_highPt_(9, 1.),
+    scaleFactorsDY_lowPt_ (9, 1.),
+    scaleFactorsDY_medPt_ (9, 1.),
+    scaleFactorsDY_highPt_(9, 1.)
+{
+    // ...then fill them with actual values depending on Period
+    FillHHlikeSFs(period);
+    FillTTlikeSFs(period);
+    FillDYlikeSFs(period);
+}
+
+// Destructor
+PNetSFInterface::~PNetSFInterface() {}
+
+// Fill SFs for HH-like samples
+void PNetSFInterface::FillHHlikeSFs(const std::string period)
+{
+    // Set scale factor values depending on the Era
+    if (period == "2016preVFP")
+    {
+        // pT < 500
+        scaleFactorsHH_lowPt_[0] = (1.054);            // HP central
+        scaleFactorsHH_lowPt_[1] = (1.054 + ( 0.080)); // HP up
+        scaleFactorsHH_lowPt_[2] = (1.054 + (-0.077)); // HP down
+        scaleFactorsHH_lowPt_[3] = (1.052);            // MP central
+        scaleFactorsHH_lowPt_[4] = (1.052 + ( 0.087)); // MP up
+        scaleFactorsHH_lowPt_[5] = (1.052 + (-0.081)); // MP down
+        scaleFactorsHH_lowPt_[6] = (1.032);            // LP central
+        scaleFactorsHH_lowPt_[7] = (1.032 + ( 0.096)); // LP up
+        scaleFactorsHH_lowPt_[8] = (1.032 + (-0.090)); // LP down
+
+        // 500 <= pT < 600
+        scaleFactorsHH_medPt_[0] = (1.139);            // HP central
+        scaleFactorsHH_medPt_[1] = (1.139 + ( 0.083)); // HP up
+        scaleFactorsHH_medPt_[2] = (1.139 + (-0.081)); // HP down
+        scaleFactorsHH_medPt_[3] = (1.068);            // MP central
+        scaleFactorsHH_medPt_[4] = (1.068 + ( 0.078)); // MP up
+        scaleFactorsHH_medPt_[5] = (1.068 + (-0.073)); // MP down
+        scaleFactorsHH_medPt_[6] = (1.062);            // LP central
+        scaleFactorsHH_medPt_[7] = (1.062 + ( 0.092)); // LP up
+        scaleFactorsHH_medPt_[8] = (1.062 + (-0.082)); // LP down
+
+        // pT >= 600
+        scaleFactorsHH_highPt_[0] = (1.049);            // HP central
+        scaleFactorsHH_highPt_[1] = (1.049 + ( 0.133)); // HP up
+        scaleFactorsHH_highPt_[2] = (1.049 + (-0.130)); // HP down
+        scaleFactorsHH_highPt_[3] = (0.996);            // MP central
+        scaleFactorsHH_highPt_[4] = (0.996 + ( 0.101)); // MP up
+        scaleFactorsHH_highPt_[5] = (0.996 + (-0.097)); // MP down
+        scaleFactorsHH_highPt_[6] = (1.002);            // LP central
+        scaleFactorsHH_highPt_[7] = (1.002 + ( 0.106)); // LP up
+        scaleFactorsHH_highPt_[8] = (1.002 + (-0.101)); // LP down
+    }
+    else if (period == "2016postVFP")
+    {
+        // pT < 500
+        scaleFactorsHH_lowPt_[0] = (1.031);            // HP central
+        scaleFactorsHH_lowPt_[1] = (1.031 + ( 0.050)); // HP up
+        scaleFactorsHH_lowPt_[2] = (1.031 + (-0.046)); // HP down
+        scaleFactorsHH_lowPt_[3] = (1.029);            // MP central
+        scaleFactorsHH_lowPt_[4] = (1.029 + ( 0.051)); // MP up
+        scaleFactorsHH_lowPt_[5] = (1.029 + (-0.045)); // MP down
+        scaleFactorsHH_lowPt_[6] = (1.031);            // LP central
+        scaleFactorsHH_lowPt_[7] = (1.031 + ( 0.058)); // LP up
+        scaleFactorsHH_lowPt_[8] = (1.031 + (-0.050)); // LP down
+
+        // 500 <= pT < 600
+        scaleFactorsHH_medPt_[0] = (1.055);            // HP central
+        scaleFactorsHH_medPt_[1] = (1.055 + ( 0.069)); // HP up
+        scaleFactorsHH_medPt_[2] = (1.055 + (-0.067)); // HP down
+        scaleFactorsHH_medPt_[3] = (1.070);            // MP central
+        scaleFactorsHH_medPt_[4] = (1.070 + ( 0.066)); // MP up
+        scaleFactorsHH_medPt_[5] = (1.070 + (-0.062)); // MP down
+        scaleFactorsHH_medPt_[6] = (1.089);            // LP central
+        scaleFactorsHH_medPt_[7] = (1.089 + ( 0.076)); // LP up
+        scaleFactorsHH_medPt_[8] = (1.089 + (-0.068)); // LP down
+
+        // pT >= 600
+        scaleFactorsHH_highPt_[0] = (1.088);            // HP central
+        scaleFactorsHH_highPt_[1] = (1.088 + ( 0.076)); // HP up
+        scaleFactorsHH_highPt_[2] = (1.088 + (-0.072)); // HP down
+        scaleFactorsHH_highPt_[3] = (1.077);            // MP central
+        scaleFactorsHH_highPt_[4] = (1.077 + ( 0.067)); // MP up
+        scaleFactorsHH_highPt_[5] = (1.077 + (-0.059)); // MP down
+        scaleFactorsHH_highPt_[6] = (1.057);            // LP central
+        scaleFactorsHH_highPt_[7] = (1.057 + ( 0.077)); // LP up
+        scaleFactorsHH_highPt_[8] = (1.057 + (-0.056)); // LP down
+    }
+    else if (period == "2017")
+    {
+        // pT < 500
+        scaleFactorsHH_lowPt_[0] = (1.055);            // HP central
+        scaleFactorsHH_lowPt_[1] = (1.055 + ( 0.057)); // HP up
+        scaleFactorsHH_lowPt_[2] = (1.055 + (-0.054)); // HP down
+        scaleFactorsHH_lowPt_[3] = (1.006);            // MP central
+        scaleFactorsHH_lowPt_[4] = (1.006 + ( 0.052)); // MP up
+        scaleFactorsHH_lowPt_[5] = (1.006 + (-0.052)); // MP down
+        scaleFactorsHH_lowPt_[6] = (0.966);            // LP central
+        scaleFactorsHH_lowPt_[7] = (0.966 + ( 0.055)); // LP up
+        scaleFactorsHH_lowPt_[8] = (0.966 + (-0.057)); // LP down
+
+        // 500 <= pT < 600
+        scaleFactorsHH_medPt_[0] = (1.067);            // HP central
+        scaleFactorsHH_medPt_[1] = (1.067 + ( 0.057)); // HP up
+        scaleFactorsHH_medPt_[2] = (1.067 + (-0.055)); // HP down
+        scaleFactorsHH_medPt_[3] = (1.051);            // MP central
+        scaleFactorsHH_medPt_[4] = (1.051 + ( 0.056)); // MP up
+        scaleFactorsHH_medPt_[5] = (1.051 + (-0.055)); // MP down
+        scaleFactorsHH_medPt_[6] = (1.021);            // LP central
+        scaleFactorsHH_medPt_[7] = (1.021 + ( 0.053)); // LP up
+        scaleFactorsHH_medPt_[8] = (1.021 + (-0.052)); // LP down
+
+        // pT >= 600
+        scaleFactorsHH_highPt_[0] = (1.045);            // HP central
+        scaleFactorsHH_highPt_[1] = (1.045 + ( 0.045)); // HP up
+        scaleFactorsHH_highPt_[2] = (1.045 + (-0.046)); // HP down
+        scaleFactorsHH_highPt_[3] = (0.991);            // MP central
+        scaleFactorsHH_highPt_[4] = (0.991 + ( 0.038)); // MP up
+        scaleFactorsHH_highPt_[5] = (0.991 + (-0.043)); // MP down
+        scaleFactorsHH_highPt_[6] = (0.979);            // LP central
+        scaleFactorsHH_highPt_[7] = (0.979 + ( 0.035)); // LP up
+        scaleFactorsHH_highPt_[8] = (0.979 + (-0.038)); // LP down
+    }
+    else if (period == "2018" || period == "2022" || period == "2023")
+    {
+        // pT < 500
+        scaleFactorsHH_lowPt_[0] = (0.994);            // HP central
+        scaleFactorsHH_lowPt_[1] = (0.994 + ( 0.064)); // HP up
+        scaleFactorsHH_lowPt_[2] = (0.994 + (-0.064)); // HP down
+        scaleFactorsHH_lowPt_[3] = (0.966);            // MP central
+        scaleFactorsHH_lowPt_[4] = (0.966 + ( 0.056)); // MP up
+        scaleFactorsHH_lowPt_[5] = (0.966 + (-0.057)); // MP down
+        scaleFactorsHH_lowPt_[6] = (0.921);            // LP central
+        scaleFactorsHH_lowPt_[7] = (0.921 + ( 0.071)); // LP up
+        scaleFactorsHH_lowPt_[8] = (0.921 + (-0.077)); // LP down
+
+        // 500 <= pT < 600
+        scaleFactorsHH_medPt_[0] = (1.072);            // HP central
+        scaleFactorsHH_medPt_[1] = (1.072 + ( 0.041)); // HP up
+        scaleFactorsHH_medPt_[2] = (1.072 + (-0.036)); // HP down
+        scaleFactorsHH_medPt_[3] = (1.033);            // MP central
+        scaleFactorsHH_medPt_[4] = (1.033 + ( 0.030)); // MP up
+        scaleFactorsHH_medPt_[5] = (1.033 + (-0.025)); // MP down
+        scaleFactorsHH_medPt_[6] = (1.006);            // LP central
+        scaleFactorsHH_medPt_[7] = (1.006 + ( 0.024)); // LP up
+        scaleFactorsHH_medPt_[8] = (1.006 + (-0.026)); // LP down
+
+        // pT >= 600
+        scaleFactorsHH_highPt_[0] = (1.046);            // HP central
+        scaleFactorsHH_highPt_[1] = (1.046 + ( 0.038)); // HP up
+        scaleFactorsHH_highPt_[2] = (1.046 + (-0.038)); // HP down
+        scaleFactorsHH_highPt_[3] = (1.010);            // MP central
+        scaleFactorsHH_highPt_[4] = (1.010 + ( 0.030)); // MP up
+        scaleFactorsHH_highPt_[5] = (1.010 + (-0.035)); // MP down
+        scaleFactorsHH_highPt_[6] = (1.001);            // LP central
+        scaleFactorsHH_highPt_[7] = (1.001 + ( 0.035)); // LP up
+        scaleFactorsHH_highPt_[8] = (1.001 + (-0.037)); // LP down
+    }
+    else
+    {
+        std::string errorMessage = "PNseSFInterface - Invalid period: "
+                                 + period
+                                 + " [options are: 2016preVFP/2016postVFP/2017/2018/2022/2023]";
+        throw std::logic_error(errorMessage);
+    }
+}
+
+// Fill SFs for TT-like samples
+void PNetSFInterface::FillTTlikeSFs(const std::string period)
+{
+    // Set scale factor values depending on the Era
+    if (period == "2016preVFP")
+    {
+        // pT < 300
+        // HP and MP SFs not yet available - default to 1
+        scaleFactorsTT_lowPt_[6] = (0.5942130);                 // LP central
+        scaleFactorsTT_lowPt_[7] = (0.5942130 + ( 0.27098274)); // LP up
+        scaleFactorsTT_lowPt_[8] = (0.5942130 + (-0.27098274)); // LP down
+
+        // 300 <= pT < 400
+        // HP and MP SFs not yet available - default to 1
+        scaleFactorsTT_medPt_[6] = (0.76523553);                 // LP central
+        scaleFactorsTT_medPt_[7] = (0.76523553 + ( 0.27098274)); // LP up
+        scaleFactorsTT_medPt_[8] = (0.76523553 + (-0.27098274)); // LP down
+
+        // pT >= 400
+        // HP and MP SFs not yet available - default to 1
+        scaleFactorsTT_highPt_[6] = (0.66079032);                 // LP central
+        scaleFactorsTT_highPt_[7] = (0.66079032 + ( 0.37631591)); // LP up
+        scaleFactorsTT_highPt_[8] = (0.66079032 + (-0.37631591)); // LP down
+    }
+    else if (period == "2016postVFP")
+    {
+        // Do nothing: SFs not yet available - default to 1 for all cases
+    }
+    else if (period == "2017")
+    {
+        // Do nothing: SFs not yet available - default to 1 for all cases
+    }
+    else if (period == "2018" || period == "2022" || period == "2023")
+    {
+        // Do nothing: SFs not yet available - default to 1 for all cases
+    }
+    else
+    {
+        std::string errorMessage = "PNseSFInterface - Invalid period: "
+                                 + period
+                                 + " [options are: 2016preVFP/2016postVFP/2017/2018/2022/2023]";
+        throw std::logic_error(errorMessage);
+    }
+}
+
+// Fill SFs for DY-like samples
+void PNetSFInterface::FillDYlikeSFs(const std::string period)
+{
+    // Set scale factor values depending on the Era
+    if (period == "2016preVFP")
+    {
+        // pT < 300
+        // HP and MP SFs not yet available - default to 1
+        scaleFactorsDY_lowPt_[6] = (0.79969335);                // LP central
+        scaleFactorsDY_lowPt_[7] = (0.79969335 + ( 0.1880848)); // LP up
+        scaleFactorsDY_lowPt_[8] = (0.79969335 + (-0.1880848)); // LP down
+
+        // 300 <= pT < 400
+        // HP and MP SFs not yet available - default to 1
+        scaleFactorsDY_medPt_[6] = (1.27936957);                 // LP central
+        scaleFactorsDY_medPt_[7] = (1.27936957 + ( 0.29244537)); // LP up
+        scaleFactorsDY_medPt_[8] = (1.27936957 + (-0.29244537)); // LP down
+
+        // pT >= 400
+        scaleFactorsDY_highPt_[6] = (1.57300599);                 // LP central
+        scaleFactorsDY_highPt_[7] = (1.57300599 + ( 0.47988435)); // LP up
+        scaleFactorsDY_highPt_[8] = (1.57300599 + (-0.47988435)); // LP down
+    }
+    else if (period == "2016postVFP")
+    {
+        // Do nothing: SFs not yet available - default to 1 for all cases
+    }
+    else if (period == "2017")
+    {
+        // Do nothing: SFs not yet available - default to 1 for all cases
+    }
+    else if (period == "2018" || period == "2022" || period == "2023")
+    {
+        // Do nothing: SFs not yet available - default to 1 for all cases
+    }
+    else
+    {
+        std::string errorMessage = "PNseSFInterface - Invalid period: "
+                                 + period
+                                 + " [options are: 2016preVFP/2016postVFP/2017/2018/2022/2023]";
+        throw std::logic_error(errorMessage);
+    }
+}
+
+// Get the SF vector based on jet pT and sampleType
+std::vector<float> PNetSFInterface::getSFvec(const ROOT::VecOps::RVec<float> FatJet_pt, const int fatjet_idx,
+                                             const std::vector<bool> genAk8_Zbb_matches, const std::vector<bool> genAk8_Hbb_matches,
+                                             const std::string sampleType)
+{
+
+    // Initialize output SF vector
+    std::vector<float> SFvec(9, 1.);
+
+    // Check that the AK8 jet exists
+    if (fatjet_idx == -1)
+    {
+        return SFvec;
+    }
+
+    // "Other" backgrounds
+    if (sampleType == "other")
+    {
+        return SFvec;
+    }
+
+    // Get pT of selected fatjet
+    float pT = FatJet_pt.at(fatjet_idx);
+
+    // HH-like samples SF
+    if (sampleType == "HHlike")
+    {
+        // If the AK8 jet is not matched to a gen Z/H->bb resonance, return 1.
+        if ( !genAk8_Zbb_matches.at(fatjet_idx) && !genAk8_Hbb_matches.at(fatjet_idx) )
+        {
+            return SFvec;
+        }
+
+        // Else set the pT-dependent SF
+        if (pT < 500)
+        {
+            SFvec = scaleFactorsHH_lowPt_;
+        }
+        else if (pT >= 500 && pT < 600)
+        {
+            SFvec = scaleFactorsHH_medPt_;
+        }
+        else /* pT >= 600 */
+        {
+            SFvec = scaleFactorsHH_highPt_;
+        }
+    }
+
+    // TT-like samples SF
+    if (sampleType == "TTlike")
+    {
+        // Set the pT-dependent SF
+        if (pT < 300)
+        {
+            SFvec = scaleFactorsTT_lowPt_;
+        }
+        else if (pT >= 300 && pT < 400)
+        {
+            SFvec = scaleFactorsTT_medPt_;
+        }
+        else /* pT >= 400 */
+        {
+            SFvec = scaleFactorsTT_highPt_;
+        }
+    }
+
+    // DY-like samples SF
+    if (sampleType == "DYlike")
+    {
+        // Set the pT-dependent SF
+        if (pT < 300)
+        {
+            SFvec = scaleFactorsDY_lowPt_;
+        }
+        else if (pT >= 300 && pT < 400)
+        {
+            SFvec = scaleFactorsDY_medPt_;
+        }
+        else /* pT >= 400 */
+        {
+            SFvec = scaleFactorsDY_highPt_;
+        }
+    }
+
+    // Return final SF vector
+    return SFvec;
+}


### PR DESCRIPTION
#### PR Description
This PR adds the needed classes for storing the pNet SFs.
- Class `AK8GenInterface`:
  - Loops on  gen particles to identify H/Z->bb resonances
  - Loop on FatJets and store in 2 new branches ("genAk8_Zbb_matches", "genAk8_Hbb_matches") whether each FatJet is matched or not
-  Class `PNetSFInterface`:
   - Depending on sample-type, pT of the fatjet, working point and MC-matching branches: sets the PNets SF value
   - Samples are split in HH-like, DY-like, TT-like (we might want to review this for the ZZ/ZH analysis)

Two Python modules are alsio added to handle the `c++` classes:
 -  `AK8GenRDF`
 - `HH_pNetSFRDF`


#### PR Validation
Unfortunately at the moment I don't have the setup ready to test PR and make sure all is ok.
I write here here the instructions on how you can download it and quickly test it:
```
cd Tools/Tools
git remote add francesco git@github.com:francescobrivio/InferenceTools.git
git pull francesco add_pNetSF
cd -
source setup.sh
```

#### Open points
- The SFs for Run2 are **not yet** fully complete, some WPs and year are still work in progress (FYI @spalluotto )
- There are a few points to address, see comments below directly in the code

